### PR TITLE
Add support for code sandbox workspaces and update DB seed script

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -1,0 +1,18 @@
+{
+    // These tasks will run in order when initializing your CodeSandbox project.
+    "setupTasks": [
+      {
+        "name": "Install Dependencies",
+        "command": "yarn install"
+      }
+    ],
+  
+    // These tasks can be run from CodeSandbox. Running one will open a log in the app.
+    "tasks": {
+      "heroku-postbuild": {
+        "name": "heroku-postbuild",
+        "command": "yarn heroku-postbuild",
+        "runAtStart": false
+      }
+    }
+  }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
+{
+    "name": "Node.js & PostgreSQL",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/"
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // This can be used to network with other containers or with the host.
+    // "forwardPorts": [3000, 5432],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "yarn install",
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+      
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: S3^x*t*4UBjor7eA
+      POSTGRES_USER: lp-api
+      POSTGRES_DB: local
+    ports:
+      - "5432:5432"
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/api/prisma/seed/index.mjs
+++ b/api/prisma/seed/index.mjs
@@ -10,90 +10,102 @@ const prisma = new PrismaClient();
 
 const seedData = async () => {
     // Users
-    users.map(user =>
-        prisma.user.upsert({
-            where: { id: user?.id },
-            update: {},
-            create: user
-        })
+    await Promise.all(
+        users.map(async user =>
+            prisma.user.upsert({
+                where: { id: user?.id },
+                update: {},
+                create: user
+            })
+        )
     );
 
     const updatedById = users[0]?.id;
     const createdById = updatedById;
 
     // Instructors
-    instructors.map(async instructor =>
-        prisma.instructor.upsert({
-            where: { id: instructor?.id },
-            update: instructor,
-            create: {
-                ...instructor,
-                updatedById,
-                createdById
-            }
-        })
+    await Promise.all(
+        instructors.map(async (instructor) =>
+            prisma.instructor.upsert({
+                where: { id: instructor?.id },
+                update: instructor,
+                create: {
+                    ...instructor,
+                    updatedById,
+                    createdById
+                }
+            })
+        )
     );
 
     // Courses
-    courses.map(async course =>
-        prisma.course.upsert({
-            where: { id: course?.id },
-            update: course,
-            create: {
-                ...course,
-                updatedById,
-                createdById
-            }
-        })
+    await Promise.all(
+        courses.map(async (course) =>
+            prisma.course.upsert({
+                where: { id: course?.id },
+                update: course,
+                create: {
+                    ...course,
+                    updatedById,
+                    createdById
+                }
+            })
+        )
     );
 
     // Sections
-    sections.map(async section =>
-        prisma.section.upsert({
-            where: { id: section?.id },
-            update: section,
-            create: {
-                ...section,
-                updatedById,
-                createdById
-            }
-        })
+    await Promise.all(
+        sections.map(async (section) =>
+            prisma.section.upsert({
+                where: { id: section?.id },
+                update: section,
+                create: {
+                    ...section,
+                    updatedById,
+                    createdById
+                }
+            })
+        )
     );
 
     // Ratings
-    ratings.map(async rating =>
-        prisma.rating.upsert({
-            where: { id: rating?.id },
-            update: rating,
-            create: {
-                ...rating,
-                updatedById,
-                createdById
-            }
-        })
+    await Promise.all(
+        ratings.map(async (rating) =>
+            prisma.rating.upsert({
+                where: { id: rating?.id },
+                update: rating,
+                create: {
+                    ...rating,
+                    updatedById,
+                    createdById
+                }
+            })
+        )
     );
 
     // Objectives
-    objectives.map(async objective =>
-        prisma.objective.upsert({
-            where: { id: objective?.id },
-            update: objective,
-            create: {
-                ...objective,
-                updatedById,
-                createdById
-            }
-        })
+    await Promise.all(
+        objectives.map(async (objective) =>
+            prisma.objective.upsert({
+                where: { id: objective?.id },
+                update: objective,
+                create: {
+                    ...objective,
+                    updatedById,
+                    createdById
+                }
+            })
+        )
     );
-
-    await prisma.$disconnect();
 };
 
 seedData()
-    .catch(e => {
+    .catch(async (e) => {
+        await prisma.$disconnect();
         console.error(`Error seeding: ${e}`);
         process.exit(1);
     })
     .finally(async () => {
+        await prisma.$disconnect();
         console.log('Seeding successfully.');
     });


### PR DESCRIPTION
Added some settings to allow codesandbox to setup a dev environment.

Also made the seed script more deterministic by wrapping each `entry.map()` in `await Promise.all()` so that subsequent create that depended on previous entries only ran after the former completed. 