### PR TITLE
Adding Students Dropdown to Evidence dialogue

### DIFF
--- a/app/src/components/dialogs/evidence/index.stories.tsx
+++ b/app/src/components/dialogs/evidence/index.stories.tsx
@@ -17,12 +17,14 @@ type Story = StoryObj<typeof meta>;
 
 const courses = fixtures.courses(3);
 const objectives = fixtures.objectives(7);
+const students = fixtures.students(12)
 
 const defaultArgs = {
     open: false,
     initialValue: '',
     objectives,
     courses,
+    students,
     uploadedOn: formatDate(faker.date.past()),
     devtool: false
 };

--- a/app/src/components/dialogs/evidence/index.tsx
+++ b/app/src/components/dialogs/evidence/index.tsx
@@ -38,6 +38,8 @@ import { DevTool } from '@hookform/devtools';
 import Editor from '../../editor';
 import FileUploadCard from '../../file-upload-card';
 import ObjectivesDropdown from '@/components/objective-dropdown';
+import StudentsDropdown from '@/components/students-dropdown';
+import { Student as TStudents } from '@/types';
 import { evidenceSchema } from './schema';
 import { get } from 'lodash';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -48,6 +50,7 @@ export type { EvidenceFormValues } from './schema';
 export type EvidenceDialogProps = DialogProps & {
     selectAllStudents: boolean;
     courses: TCourse[];
+    students: TStudents[] | undefined;
     devtool?: boolean;
     initialValue?: string;
     objectives?: TObjective[];
@@ -80,6 +83,7 @@ const EvidenceDialog: React.FC<EvidenceDialogProps> = ({
     selectAllStudents = true,
     objectives: objectivesProp,
     courses = [],
+    students = [],
     onClose,
     onError,
     onSubmit,
@@ -263,7 +267,7 @@ const EvidenceDialog: React.FC<EvidenceDialogProps> = ({
                                             />
                                         </Grid>
                                         <Grid item sm={12}>
-                                        <FormControl>
+                                        <FormControl fullWidth>
                                             <Grid component="label" container alignItems="center" spacing={1}>
                                                 <FormLabel id="switch-label" sx={{paddingLeft: '10px'}}>Students: </FormLabel>
                                                 <FormControlLabel control={
@@ -275,18 +279,9 @@ const EvidenceDialog: React.FC<EvidenceDialogProps> = ({
                                             </Grid>
                                             {allStudentsSelected === false && (
                                                 <FormControl>
-                                                    <Select
-                                                        value={selectedStudent}
-                                                        onChange={handleStudentChange}
-                                                        displayEmpty
-                                                        fullWidth
-                                                        inputProps={{ 'aria-label': 'Select student' }}
-                                                    >
-                                                        <MenuItem value="" disabled>Select Student</MenuItem>
-                                                        <MenuItem value="student1">Student 1</MenuItem>
-                                                        <MenuItem value="student2">Student 2</MenuItem>
-                                                        <MenuItem value="student3">Student 3</MenuItem>
-                                                    </Select>
+                                                    <StudentsDropdown
+                                                        students={students}
+                                                    />
                                                 </FormControl>
                                             )}
                                             </FormControl>

--- a/app/src/components/students-dropdown/index.tsx
+++ b/app/src/components/students-dropdown/index.tsx
@@ -10,7 +10,7 @@ import TextField from '@mui/material/TextField';
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" sx={{ backgroundColor: "primary" }} />;
 
-export type ObjectivesDropdownProps = {
+export type StudentsDropdownProps = {
     students: TStudents[] | undefined;
     value?: TStudents[] | undefined;
     inputValue?: string | undefined;
@@ -18,7 +18,7 @@ export type ObjectivesDropdownProps = {
     onHandleInputChange?: (event: any, value: string) => void;
 }
 
-const ObjectivesDropdown: React.FC<ObjectivesDropdownProps> = ({
+const StudentsDropdown: React.FC<StudentsDropdownProps> = ({
     students = [],
     value,
     inputValue,
@@ -59,4 +59,4 @@ const ObjectivesDropdown: React.FC<ObjectivesDropdownProps> = ({
       );
 };
 
-export default ObjectivesDropdown
+export default StudentsDropdown


### PR DESCRIPTION
- Navigate to the Evidence drawer and verify that the new student multi-select is in the drawer. 
- Verify that when you toggle off the switch, that the student selection pops up
- Select multiple students - you should only see two chips when you click outside of the component
- When you toggle back to 'all students' verify that the student select disappears
- 